### PR TITLE
Use PolyKinds

### DIFF
--- a/Control/Monad/Indexed/Free.hs
+++ b/Control/Monad/Indexed/Free.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs, MultiParamTypeClasses, FlexibleInstances, Rank2Types #-}
+{-# LANGUAGE GADTs, MultiParamTypeClasses, FlexibleInstances, Rank2Types, PolyKinds, UndecidableInstances #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Monad.Indexed.Free

--- a/Control/Monad/Indexed/Free/Class.hs
+++ b/Control/Monad/Indexed/Free/Class.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies, PolyKinds #-}
 module Control.Monad.Indexed.Free.Class (IxMonadFree(..), iliftFree) where
 import Control.Monad.Indexed
 

--- a/Control/Monad/Indexed/Trans/Free.hs
+++ b/Control/Monad/Indexed/Trans/Free.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs, MultiParamTypeClasses, FlexibleInstances, Rank2Types #-}
+{-# LANGUAGE GADTs, MultiParamTypeClasses, FlexibleInstances, Rank2Types, PolyKinds, UndecidableInstances #-}
 module Control.Monad.Indexed.Trans.Free (IxFreeF(..), IxFreeT(..), transIxFreeT, module Control.Monad.Indexed.Free.Class) where
 
 import Control.Applicative

--- a/Control/MonadPlus/Indexed/Free.hs
+++ b/Control/MonadPlus/Indexed/Free.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GADTs, FlexibleInstances, MultiParamTypeClasses #-}
+{-# LANGUAGE GADTs, FlexibleInstances, MultiParamTypeClasses, PolyKinds, UndecidableInstances  #-}
 module Control.MonadPlus.Indexed.Free (IxFree(..), module Control.Monad.Indexed.Free.Class) where
 
 import Control.Applicative


### PR DESCRIPTION
Enabling the PolyKinds extension allows free indexed monads to use other indexing types than `Type`. As a result some instances require the `UndecidableInstances` extension.